### PR TITLE
Fix client hook usage in server component

### DIFF
--- a/src/app/components/BackOfficeLayout.tsx
+++ b/src/app/components/BackOfficeLayout.tsx
@@ -18,6 +18,7 @@ import {
   ChevronDown,
   Database
 } from 'lucide-react';
+import { AuthModalWrapper } from './AuthModalWrapper';
 
 interface BackOfficeLayoutProps {
   children: React.ReactNode;
@@ -199,6 +200,9 @@ export function BackOfficeLayout({ children }: BackOfficeLayoutProps) {
           </div>
         </main>
       </div>
+      
+      {/* Auth Modal */}
+      <AuthModalWrapper />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { I18nProvider } from "./i18n-mock";
 import { BackOfficeLayout } from "./components/BackOfficeLayout";
 import { SettingsProvider } from "./contexts/SettingsContext";
 import { AuthProvider } from "./contexts/AuthContext";
-import { AuthModalWrapper } from "./components/AuthModalWrapper";
 import { Toaster } from "react-hot-toast";
 
 const geistSans = Geist({
@@ -39,7 +38,6 @@ export default function RootLayout({
               <BackOfficeLayout>
                 {children}
               </BackOfficeLayout>
-              <AuthModalWrapper />
             </SettingsProvider>
           </AuthProvider>
         </I18nProvider>


### PR DESCRIPTION
Move `AuthModalWrapper` to `BackOfficeLayout` to resolve server-side `useAuth()` hook error.

The `RootLayout` is a server component, and client-side hooks like `useAuth()` cannot be directly invoked within it. By moving `AuthModalWrapper` into the client-side `BackOfficeLayout`, we ensure `useAuth()` is called in the correct client environment, preventing the "Attempted to call useAuth() from the server" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-07940ddd-2872-4936-9fbb-1047c1517f64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07940ddd-2872-4936-9fbb-1047c1517f64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

