### PR TITLE
Fix nextjs project errors and warnings

### DIFF
--- a/src/app/components/BackOfficeLayout.tsx
+++ b/src/app/components/BackOfficeLayout.tsx
@@ -18,7 +18,7 @@ import {
   ChevronDown,
   Database
 } from 'lucide-react';
-import { AuthModalWrapper } from './AuthModalWrapper';
+
 
 interface BackOfficeLayoutProps {
   children: React.ReactNode;
@@ -201,8 +201,6 @@ export function BackOfficeLayout({ children }: BackOfficeLayoutProps) {
         </main>
       </div>
       
-      {/* Auth Modal */}
-      <AuthModalWrapper />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { I18nProvider } from "./i18n-mock";
 import { BackOfficeLayout } from "./components/BackOfficeLayout";
 import { SettingsProvider } from "./contexts/SettingsContext";
 import { AuthProvider } from "./contexts/AuthContext";
+import { AuthModalWrapper } from "./components/AuthModalWrapper";
 import { Toaster } from "react-hot-toast";
 
 const geistSans = Geist({
@@ -38,6 +39,7 @@ export default function RootLayout({
               <BackOfficeLayout>
                 {children}
               </BackOfficeLayout>
+              <AuthModalWrapper />
             </SettingsProvider>
           </AuthProvider>
         </I18nProvider>


### PR DESCRIPTION
Move `AuthModalWrapper` to the root layout to resolve the `useAuth()` client/server component error.

The `AuthModalWrapper` component, which uses the client-side `useAuth()` hook, was being rendered within `BackOfficeLayout`. Although `BackOfficeLayout` is a client component, it was imported into the server-rendered root layout, causing `AuthModalWrapper` to be evaluated on the server. By rendering `AuthModalWrapper` directly in the root layout, it is correctly placed within the client component boundary established by `AuthProvider`.

---
<a href="https://cursor.com/background-agent?bcId=bc-27ecac8f-7bd7-41e5-814e-fd2d012c0727">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27ecac8f-7bd7-41e5-814e-fd2d012c0727">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

